### PR TITLE
Yelp query from slash command

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,8 @@
   :plugins [[lein-ring "0.8.13"]
             [lein-pdo "0.1.1"]]
   :ring {:handler lunch-bot.handler/app
-         :port 20000}
+         :port 20000
+         :auto-reload? true}
   :aliases {"up" ["pdo" "ring" "server-headless"]}
   :profiles
   {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]

--- a/src/lunch_bot/handler.clj
+++ b/src/lunch_bot/handler.clj
@@ -22,9 +22,10 @@
         com (first (str/split (body "text") #" "))
         text (rest (str/split (body "text") #" "))]
     (cond
-      (= com "random") (yelp/get-random)
       (= com "vote") (vote/start user text)
-      :else (yelp/handle-query-request (body "text")))))
+      (= com "random") (yelp/get-random)
+      (= com "search") (yelp/handle-query-request (clojure.string/join " " text))
+      :else "What do you want?")))
 
 (defroutes app-routes
   (POST "/lunch" {body :params}

--- a/src/lunch_bot/handler.clj
+++ b/src/lunch_bot/handler.clj
@@ -17,13 +17,6 @@
 (defn- send-response [text]
   (response {:text text :headers {:content-type "application/json"}}))
 
-(defn- handle-query-request [text]
-  ;; command structure -> [category] within [increment] [unit] of [location]
-  (let [[category increment units location] (rest (re-matches #"(\w+) within (\d+) (\w+) of (.+)" text))]
-  (if (nil? category)
-    "Unparsable request"
-    (yelp/get-by-query category increment units location))))
-
 (defn- handle-request [body]
   (let [user (body "user_name")
         com (first (str/split (body "text") #" "))
@@ -31,9 +24,7 @@
     (cond
       (= com "random") (yelp/get-random)
       (= com "vote") (vote/start user text)
-      :else (handle-query-request (body "text")))))
-
-
+      :else (yelp/handle-query-request (body "text")))))
 
 (defroutes app-routes
   (POST "/lunch" {body :params}

--- a/src/lunch_bot/handler.clj
+++ b/src/lunch_bot/handler.clj
@@ -17,6 +17,13 @@
 (defn- send-response [text]
   (response {:text text :headers {:content-type "application/json"}}))
 
+(defn- handle-query-request [text]
+  ;; command structure -> [category] within [increment] [unit] of [location]
+  (let [[category increment units location] (rest (re-matches #"(\w+) within (\d+) (\w+) of (.+)" text))]
+  (if (nil? category)
+    "Unparsable request"
+    (yelp/get-by-query category increment units location))))
+
 (defn- handle-request [body]
   (let [user (body "user_name")
         com (first (str/split (body "text") #" "))
@@ -24,7 +31,7 @@
     (cond
       (= com "random") (yelp/get-random)
       (= com "vote") (vote/start user text)
-      :else "What do you want?")))
+      :else (handle-query-request (body "text")))))
 
 
 

--- a/src/lunch_bot/yelp.clj
+++ b/src/lunch_bot/yelp.clj
@@ -28,3 +28,19 @@
           rand-nth
           parse-single-result))))
 
+;;TODO: increment + units -> radius
+;;TODO: location string or lat lng
+(defn get-by-query [category increment units location]
+  (let [results (api/search yelp-client
+                             {:term category
+                              :location location
+                              :limit 10
+                              :sort (rand-int 3)
+                              :radius_filter 1000})]
+    (if (nil? (results :businesses))
+      (do
+        (println "yelp results" results)
+        "There was a problem. Sorry.")
+      (-> (results :businesses)
+          rand-nth
+          parse-single-result))))

--- a/src/lunch_bot/yelp.clj
+++ b/src/lunch_bot/yelp.clj
@@ -53,5 +53,5 @@
   ;; command structure -> [category] within [increment] [unit] of [location]
   (let [[term increment units location] (rest (re-matches #"(\w+) within (\d+) (\w+) of (.+)" text))]
   (if (nil? term)
-    "Unparsable request"
+    (str "Unparsable request " text)
     (get-by-query term increment units location))))

--- a/src/lunch_bot/yelp.clj
+++ b/src/lunch_bot/yelp.clj
@@ -16,7 +16,8 @@
 (defn- parse-single-result [result]
   (->
     (str (result :name) " - " (first (first (result :categories))) " - " (result :url))
-    (send/send-response)))
+    (send/send-response))
+    "done parse-single-result" result)
 
 (defn get-random []
   (let [results (api/search yelp-client

--- a/src/lunch_bot/yelp.clj
+++ b/src/lunch_bot/yelp.clj
@@ -13,7 +13,7 @@
 (def ^:private zipcode "07302")
 
 (defn- parse-single-result [result]
-  (result :url))
+  (str (result :name) " - " (first (first (result :categories))) " - " (result :url)))
 
 (defn get-random []
   (let [results (api/search yelp-client

--- a/src/lunch_bot/yelp.clj
+++ b/src/lunch_bot/yelp.clj
@@ -1,6 +1,7 @@
 (ns lunch-bot.yelp
   (:require [gws.yelp.client :as client]
-            [gws.yelp.api :as api]))
+            [gws.yelp.api :as api]
+            [lunch-bot.send :as send]))
 
 (def ^:private yelp-key (System/getenv "YELP_CONSUMER_KEY"))
 (def ^:private yelp-consumer-secret (System/getenv "YELP_CONSUMER_SECRET"))
@@ -13,7 +14,9 @@
 (def ^:private zipcode "07302")
 
 (defn- parse-single-result [result]
-  (str (result :name) " - " (first (first (result :categories))) " - " (result :url)))
+  (->
+    (str (result :name) " - " (first (first (result :categories))) " - " (result :url))
+    (send/send-response)))
 
 (defn get-random []
   (let [results (api/search yelp-client

--- a/src/lunch_bot/yelp.clj
+++ b/src/lunch_bot/yelp.clj
@@ -20,10 +20,10 @@
                              {:term "restaurants"
                               :location zipcode
                               :limit 10
-                              :sort (rand-int 4)
+                              :sort (rand-int 3)
                               :radius_filter 1000})]
     (if (nil? (results :businesses))
-      ("There was a problem. Sorry.")
+      "There was a problem. Sorry."
       (-> (results :businesses)
           rand-nth
           parse-single-result))))

--- a/src/lunch_bot/yelp.clj
+++ b/src/lunch_bot/yelp.clj
@@ -34,9 +34,9 @@
 
 ;;TODO: increment + units -> radius
 ;;TODO: location string or lat lng
-(defn get-by-query [category increment units location]
+(defn- get-by-query [term increment units location]
   (let [results (api/search yelp-client
-                             {:term category
+                             {:term term
                               :location location
                               :limit 10
                               :sort (rand-int 3)
@@ -48,3 +48,10 @@
       (-> (results :businesses)
           rand-nth
           parse-single-result))))
+
+(defn handle-query-request [text]
+  ;; command structure -> [category] within [increment] [unit] of [location]
+  (let [[term increment units location] (rest (re-matches #"(\w+) within (\d+) (\w+) of (.+)" text))]
+  (if (nil? term)
+    "Unparsable request"
+    (get-by-query term increment units location))))


### PR DESCRIPTION
Added ability to query yelp via slash command.
Using lunch-bot.send (slack incoming web hook) to send yelp lunch-bot yelp responses.
Bug fixes